### PR TITLE
Header column formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Override `get_filename(self, queryset)` if a dynamic filename is required.
 Whether to include `sep=<sepaator>` as the first line of the CSV file. This is useful for generating Microsoft
 Excel friendly CSV.
 
-`verbose_names` - *boolean* - Default: `True`
+`verbose_names` - *boolean* - Default: `True`  
 Whether to use capitalized verbose column names in the header of the CSV file. If `False`, field names are used
 instead.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ class DataExportView(CSVExportView):
 class DataExportView(CSVExportView):
     model = Data
     fields = "__all__"
+    verbose_names = False
+
+class DataExportView(CSVExportView):
+    model = Data
+    fields = "__all__"
 
     def get_filename(self, queryset):
         return "data-export-{!s}.csv".format(timezone.now())
@@ -96,6 +101,10 @@ Override `get_filename(self, queryset)` if a dynamic filename is required.
 `specify_separator` - *boolean* - Default: `True`  
 Whether to include `sep=<sepaator>` as the first line of the CSV file. This is useful for generating Microsoft
 Excel friendly CSV.
+
+`verbose_names` - *boolean* - Default: `True`
+Whether to use capitalized verbose column names in the header of the CSV file. If `False`, field names are used
+instead.
 
 ## CSV Writer Options
 

--- a/csv_export/views.py
+++ b/csv_export/views.py
@@ -23,6 +23,7 @@ class CSVExportView(MultipleObjectMixin, View):
     fields = None
     exclude = None
     header = True
+    verbose_names = True
     specify_separator = True  # Useful for Excel.
     filename = None
 
@@ -134,7 +135,10 @@ class CSVExportView(MultipleObjectMixin, View):
                 # field_name is a property.
                 return field_name.replace("_", " ").title()
 
-            return force_str(field.verbose_name).title()
+            if self.verbose_names:
+                return force_str(field.verbose_name).title()
+            else:
+                return force_str(field.name)
         else:
             related_field_names = field_name.split("__")
             field = model._meta.get_field(related_field_names[0])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -40,6 +40,13 @@ class CSVExportTests(TestCase):
         )
         self.assertEqual(response["Content-Disposition"], 'attachment; filename="field-tests.csv"')
 
+    def test_verbose_names(self):
+        response = self.client.get(reverse('verbose-names'))
+        self.assertEqual(
+            response.content.decode().strip(),
+            'sep=,\r\n"id","date","datetime","choice","empty_choice","integer_choice"'
+        )
+
     def test_many_to_one(self):
         bmw = Manufacturer.objects.create(name="BMW")
         Car.objects.create(name="i3", manufacturer=bmw)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     FieldTestAllView,
     FieldTestView,
+    VerboseNamesView,
     ManyToManyView,
     ManyToOneView,
     OneToOneView,
@@ -17,6 +18,7 @@ from .views import (
 urlpatterns = [
     path("fields/", FieldTestView.as_view(), name="fields"),
     path("fields-all/", FieldTestAllView.as_view(), name="fields-all"),
+    path("verbose-names/", VerboseNamesView.as_view(), name="verbose-names"),
     path("many-to-many/", ManyToManyView.as_view(), name="many-to-many"),
     path("many-to-one/", ManyToOneView.as_view(), name="many-to-one"),
     path("one-to-one/", OneToOneView.as_view(), name="one-to-one"),

--- a/tests/views.py
+++ b/tests/views.py
@@ -13,6 +13,12 @@ class FieldTestAllView(CSVExportView):
     fields = "__all__"
 
 
+class VerboseNamesView(CSVExportView):
+    model = FieldTest
+    fields = '__all__'
+    verbose_names = False
+
+
 class ManyToOneView(CSVExportView):
     model = Car
     fields = ("name", "manufacturer__name")


### PR DESCRIPTION
This PR introduces a new attribute, `verbose_names`. If `True` (default), it uses capitalized verbose column names (the original behavior). If `False`, it uses field names instead.